### PR TITLE
Branch support and deletion tracking

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -2,8 +2,12 @@
   "//": "Your DataDog keys.  They can be found in the DataDog UI under Integrations -> APIs",
   "dataDogApiKey": "yourApiKey",
   "dataDogAppKey": "yourAppKey",
+
   "//": "The ssh URL for a git repo where you want your DataDog JSON files stored.",
   "gitRepoForBackups": "git@github.com:your/backupRepo.git",
+
+  "//": "The git repo branch to use.",
+  "gitBranch": "master",
 
   "//": "(optional) Whether or not you want a DataDog event to be sent in the event that nothing ",
   "//": "has changed since the last git commit.",

--- a/lib/backup.js
+++ b/lib/backup.js
@@ -26,13 +26,14 @@ var async = require('async'),
           workDir = dir;
           git.runCommand(['clone', config.gitRepoForBackups, workDir], workDir, next);
         },
+        async.apply(git.runCommand, ['checkout', config.gitBranch]),
         async.apply(dataDog.getBoards, 'dash'),
         async.apply(dataDog.getBoards, 'screen'),
         async.apply(dataDog.getMonitors),
 
-        async.apply(git.runCommand, ['add', '.']),
+        async.apply(git.runCommand, ['add', '--all', '.']),
         async.apply(git.runCommand, ['commit', '-m', 'Automatically committed by dog-watcher script']),
-        async.apply(git.runCommand, ['push', 'origin', 'master'])
+        async.apply(git.runCommand, ['push', 'origin', config.gitBranch])
       ],
       function(error) {
         var success,

--- a/lib/dataDog.js
+++ b/lib/dataDog.js
@@ -70,6 +70,7 @@ var async = require('async'),
    */
   getBoards = function (type, outputDir, callback) {
     logger.debug('getBoards(' + type + ')');
+    removeFiles(outputDir, type);
     async.waterfall(
       [
         async.apply(makeDataDogRequest, type, null),
@@ -93,6 +94,27 @@ var async = require('async'),
   },
 
   /**
+   * Remove all the files in dir1 + dir2
+   */
+  removeFiles = function(dir1, dir2) {
+
+    var directory = path.resolve(dir1, dir2);
+
+    logger.debug('Remove Files Directory: ' + directory);
+
+    fs.readdir(directory, (err, files) => {
+      if (err) throw err;
+    
+      for (const file of files) {
+        fs.unlink(path.join(directory, file), err => {
+          if (err) throw err;
+        });
+        logger.debug('Remove File: ' + file);
+      }
+    });
+  },
+
+  /**
    * Gets the specified board and saves its JSON representation in a type-specific subdirectory
    * under the specified output directory.
    * @param boardInfo Object that includes the board's id and title
@@ -112,6 +134,7 @@ var async = require('async'),
           fs.writeJson(path.resolve(targetDir,
               boardInfo.id + '-' + changeCase.snake(boardInfo.title || 'untitled') + '.json'),
             board, next);
+            logger.debug('Board Title: ' + boardInfo.title);
         }
       ],
       function(error) {


### PR DESCRIPTION
Add support to specify a branch. Branch must exist before running the script.
Files are removed first so that deleted boards can be tracked.
