### PR TITLE
delete overall_state_modified field in monitor

### DIFF
--- a/lib/dataDog.js
+++ b/lib/dataDog.js
@@ -140,6 +140,7 @@ module.exports = config => {
             // changed every time its state changes.
             monitors.forEach(function(monitor) {
               delete monitor.overall_state;
+              delete monitor.overall_state_modified;
             });
             fs.writeJson(path.resolve(targetDir, 'monitors.json'),
               monitors, next);


### PR DESCRIPTION
* Delete the overall_state_modified field in monitor.json to prevent dog-watcher commit this field's change to the commit history