### PR TITLE
feat(backup): add gitBranchForBackups config option

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -5,6 +5,9 @@
   "//": "The ssh URL for a git repo where you want your DataDog JSON files stored.",
   "gitRepoForBackups": "git@github.com:your/backupRepo.git",
 
+  "//": "(optional) Branch to use if not the default ('master').",
+  "gitBranchForBackups": "main",
+
   "//": "(optional) Whether or not you want a DataDog event to be sent in the event that nothing ",
   "//": "has changed since the last git commit.",
   "sendEventOnNoop": "false",

--- a/lib/backup.js
+++ b/lib/backup.js
@@ -13,6 +13,7 @@ module.exports = config => {
       dataDog = require('./dataDog.js')(config),
       git = require('./git.js')(config),
       logger = log4js.getLogger('dog-watcher'),
+      gitBranch = config.gitBranchForBackups || "master",
 
       workDir,
 
@@ -33,7 +34,7 @@ module.exports = config => {
 
               async.apply(git.runCommand, ['add', '.']),
               async.apply(git.runCommand, ['commit', '-m', 'Automatically committed by dog-watcher script']),
-              async.apply(git.runCommand, ['push', 'origin', 'master'])
+              async.apply(git.runCommand, ['push', 'origin', gitBranch])
             ],
             function (error) {
               var success,


### PR DESCRIPTION
Given GitHub's upcoming changes to default branches, as well as the interest within some organizations to use a default branch other than "master", support configuring gitBranchForBackups.

This continues to use 'master' as the default branch, vs. requiring the setting to be configured, for backwards compatibility.